### PR TITLE
fix: generate description of directives.

### DIFF
--- a/integrations/poem/Cargo.toml
+++ b/integrations/poem/Cargo.toml
@@ -15,7 +15,8 @@ version = "7.0.15"
 async-graphql.workspace = true
 
 futures-util = { workspace = true, default-features = false }
-poem = { version = "3.0.0", features = ["websocket"] }
+# poem@3.1.7 requires Rust 1.83
+poem = { version = "=3.1.6", features = ["websocket"] }
 serde_json.workspace = true
 tokio-util = { workspace = true, default-features = false, features = [
     "compat",

--- a/src/registry/export_sdl.rs
+++ b/src/registry/export_sdl.rs
@@ -152,7 +152,7 @@ impl Registry {
                 return;
             }
 
-            writeln!(sdl, "{}", directive.sdl()).ok();
+            writeln!(sdl, "{}", directive.sdl(&options)).ok();
         });
 
         if options.federation {
@@ -664,7 +664,7 @@ impl Registry {
     }
 }
 
-fn write_description(
+pub(super) fn write_description(
     sdl: &mut String,
     options: &SDLExportOptions,
     level: usize,

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -727,8 +727,15 @@ pub struct MetaDirective {
 }
 
 impl MetaDirective {
-    pub(crate) fn sdl(&self) -> String {
-        let mut sdl = format!("directive @{}", self.name);
+    pub(crate) fn sdl(&self, options: &SDLExportOptions) -> String {
+        let mut sdl = String::new();
+
+        if let Some(description) = &self.description {
+            self::export_sdl::write_description(&mut sdl, options, 0, description);
+        }
+
+        write!(sdl, "directive @{}", self.name).ok();
+
         if !self.args.is_empty() {
             let args = self
                 .args
@@ -903,8 +910,8 @@ impl Registry {
         self.add_directive(MetaDirective {
             name: "oneOf".into(),
             description: Some(
-                "Indicates that an Input Object is a OneOf Input Object (and thus requires
-                        exactly one of its field be provided)"
+                "Indicates that an Input Object is a OneOf Input Object (and thus requires \
+                exactly one of its field be provided)"
                     .to_string(),
             ),
             locations: vec![__DirectiveLocation::INPUT_OBJECT],

--- a/tests/directive.rs
+++ b/tests/directive.rs
@@ -167,7 +167,10 @@ pub async fn test_includes_deprecated_directive() {
     let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
 
     assert!(schema.sdl().contains(
-        r#""Marks an element of a GraphQL schema as no longer supported."
+        r#"
+"""
+Marks an element of a GraphQL schema as no longer supported.
+"""
 directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE"#,
     ))
 }

--- a/tests/directive.rs
+++ b/tests/directive.rs
@@ -167,7 +167,7 @@ pub async fn test_includes_deprecated_directive() {
     let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
 
     assert!(schema.sdl().contains(
-        r#""Marks an element of a GraphQL schema as no longer supported."\n
+        r#""Marks an element of a GraphQL schema as no longer supported."
         directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE"#,
     ))
 }

--- a/tests/directive.rs
+++ b/tests/directive.rs
@@ -168,7 +168,7 @@ pub async fn test_includes_deprecated_directive() {
 
     assert!(schema.sdl().contains(
         r#""Marks an element of a GraphQL schema as no longer supported."
-        directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE"#,
+directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE"#,
     ))
 }
 

--- a/tests/directive.rs
+++ b/tests/directive.rs
@@ -20,7 +20,7 @@ pub async fn test_directive_skip() {
                 value5: value @skip(if: true)
                 value6: value @skip(if: false)
             }
-            
+
             query {
                 value1: value @skip(if: true)
                 value2: value @skip(if: false)
@@ -166,7 +166,10 @@ pub async fn test_includes_deprecated_directive() {
 
     let schema = Schema::new(Query, EmptyMutation, EmptySubscription);
 
-    assert!(schema.sdl().contains(r#"directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE"#))
+    assert!(schema.sdl().contains(
+        r#""Marks an element of a GraphQL schema as no longer supported."\n
+        directive @deprecated(reason: String = "No longer supported") on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE"#,
+    ))
 }
 
 #[tokio::test]

--- a/tests/schemas/test_dynamic_schema.graphql
+++ b/tests/schemas/test_dynamic_schema.graphql
@@ -40,7 +40,13 @@ scalar TestScalar @json
 
 union TestUnion @wrap = OutputType | OutputType2
 
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 schema {
 	query: Query

--- a/tests/schemas/test_entity_inaccessible.schema.graphql
+++ b/tests/schemas/test_entity_inaccessible.schema.graphql
@@ -65,7 +65,13 @@ extend type Query {
 }
 
 
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 extend schema @link(
 	url: "https://specs.apollo.dev/federation/v2.3",

--- a/tests/schemas/test_entity_tag.schema.graphql
+++ b/tests/schemas/test_entity_tag.schema.graphql
@@ -65,7 +65,13 @@ extend type Query {
 }
 
 
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 extend schema @link(
 	url: "https://specs.apollo.dev/federation/v2.3",

--- a/tests/schemas/test_fed2_compose.schema.graphql
+++ b/tests/schemas/test_fed2_compose.schema.graphql
@@ -17,8 +17,14 @@ type Subscription @testDirective(scope: "object type", input: 3) {
 	anotherValue: SimpleValue!
 }
 
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @noArgsDirective on FIELD_DEFINITION
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @testDirective(scope: String!, input: Int!, opt: Int) on FIELD_DEFINITION | OBJECT
 extend schema @link(

--- a/tests/schemas/test_fed2_compose_2.schema.graphql
+++ b/tests/schemas/test_fed2_compose_2.schema.graphql
@@ -44,8 +44,17 @@ type TestSimpleObject @type_directive_object(description: "This is OBJECT in Sim
 	field: String! @type_directive_field_definition(description: "This is FIELD_DEFINITION in SimpleObject")
 }
 
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Indicates that an Input Object is a OneOf Input Object (and thus requires exactly one of its field be provided)
+"""
 directive @oneOf on INPUT_OBJECT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 directive @type_directive_argument_definition(description: String!) on ARGUMENT_DEFINITION
 directive @type_directive_enum(description: String!) on ENUM

--- a/tests/schemas/test_fed2_link.schema.graphqls
+++ b/tests/schemas/test_fed2_link.schema.graphqls
@@ -20,7 +20,13 @@ extend type User @key(fields: "id") {
 	reviews: [Review!]!
 }
 
+"""
+Directs the executor to include this field or fragment only when the `if` argument is true.
+"""
 directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+Directs the executor to skip this field or fragment when the `if` argument is true.
+"""
 directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 extend schema @link(
 	url: "https://specs.apollo.dev/federation/v2.3",


### PR DESCRIPTION
## Pull Request Overview

### Changes

1. **Modification of `MetaDirective` struct's `sdl` method**:
   - Added `SDLExportOptions` argument to the `sdl` method to include directive descriptions.
   - Used the `write_description` function to write descriptions into the `sdl`.

2. **Visibility change of `write_description` function**:
   - Changed the visibility of the `write_description` function to `pub(super)` to allow access from `MetaDirective::sdl`.

3. **Test updates**:
   - Updated the `test_includes_deprecated_directive` test to include directive descriptions.

4. **Update `integrations/poem/Cargo.toml`**:
   - Fixed the version of the `poem` crate to `3.1.6` (as `3.1.7` requires Rust 1.83).

### Reasons for Changes

- To improve the readability and understanding of the schema by including descriptions in the SDL output of directives.
  - [GraphQL Specification - Directives](https://spec.graphql.org/October2021/#sec-Type-System.Directives)
- To avoid compatibility issues by fixing the version of the `poem` crate.
